### PR TITLE
DM-37215: disable tests

### DIFF
--- a/doc/changes/DM-37215.misc.rst
+++ b/doc/changes/DM-37215.misc.rst
@@ -1,0 +1,1 @@
+Disable tests until parsl can be installed in the LSST base env.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,9 +99,9 @@ line_length = 110
 [tool.lsst_versions]
 write_to = "python/lsst/ctrl/bps/parsl/version.py"
 
-[tool.pytest.ini_options]
-addopts = "--flake8"
-flake8-ignore = ["W503", "E203", "N802", "N803", "N806", "N812", "N815", "N816"]
+#[tool.pytest.ini_options]
+#addopts = "--flake8"
+#flake8-ignore = ["W503", "E203", "N802", "N803", "N806", "N812", "N815", "N816"]
 
 [tool.pydocstyle]
 convention = "numpy"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,15 @@
-from lsst.ctrl.bps import BpsConfig
-from lsst.ctrl.bps.parsl.configuration import get_bps_config_value
+import pytest
 from lsst.daf.butler import Config
 
 
+@pytest.mark.skip(reason="parsl not in LSST environment")
 def test_config():
     """Super-basic test of configuration reading
 
     This is intended as a test of testing more than anything else.
     """
+    from lsst.ctrl.bps import BpsConfig
+    from lsst.ctrl.bps.parsl.configuration import get_bps_config_value
+
     config = BpsConfig(Config.fromString("foo: bar"))  # BpsConfig doesn't work directly with fromString
     assert get_bps_config_value(config, "foo", str) == "bar"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,2 +1,6 @@
+import pytest
+
+
+@pytest.mark.skip(reason="parsl not in LSST environment")
 def test_import():
     import lsst.ctrl.bps.parsl  # noqa


### PR DESCRIPTION
Tests (including flake8) are importing parsl, which isn't in base LSST env, so temporarily disabling them.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
