### PR TITLE
Slurm: add support for getting scheduler_options from BPS config

### DIFF
--- a/doc/changes/DM-32764.feature.rst
+++ b/doc/changes/DM-32764.feature.rst
@@ -1,0 +1,1 @@
+Add support for getting ``scheduler_options`` from BPS configuration for Slurm.

--- a/doc/lsst.ctrl.bps.parsl/use.rst
+++ b/doc/lsst.ctrl.bps.parsl/use.rst
@@ -103,6 +103,7 @@ Optional settings are:
 * ``cores_per_node`` (`int`): number of cores per node for each Slurm job; by default we use all cores on the node.
 * ``mem_per_node`` (`int`): memory per node (GB) for each Slurm job; by default we use whatever Slurm gives us.
 * ``qos`` (`str`): quality of service to request for each Slurm job; by default we use whatever Slurm gives us.
+* ``scheduler_options`` (`str`): text to prepend to the Slurm submission script (each line usually starting with ``#SBATCH``); empty string by default.
 
 .. |HighThroughputExecutor| replace:: ``HighThroughputExecutor``
 .. _HighThroughputExecutor: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.HighThroughputExecutor.html#parsl.executors.HighThroughputExecutor

--- a/python/lsst/ctrl/bps/parsl/sites/slurm.py
+++ b/python/lsst/ctrl/bps/parsl/sites/slurm.py
@@ -48,6 +48,8 @@ class Slurm(SiteConfig):
       default we use whatever Slurm gives us.
     - ``singleton`` (`bool`): allow only one job to run at a time; by default
       ``False``.
+    - ``scheduler_options`` (`str`): text to prepend to the Slurm submission
+      script (each line usually starting with ``#SBATCH``).
     """
 
     def make_executor(
@@ -106,11 +108,13 @@ class Slurm(SiteConfig):
         mem_per_node = get_bps_config_value(self.site, "mem_per_node", int, mem_per_node)
         qos = get_bps_config_value(self.site, "qos", str, qos)
         singleton = get_bps_config_value(self.site, "singleton", bool, singleton)
+        scheduler_options = get_bps_config_value(self.site, "scheduler_options", str, scheduler_options)
 
         job_name = get_workflow_name(self.config)
         if scheduler_options is None:
             scheduler_options = ""
-        scheduler_options += "\n"
+        else:
+            scheduler_options += "\n"
         scheduler_options += f"#SBATCH --job-name={job_name}\n"
         if qos:
             scheduler_options += f"#SBATCH --qos={qos}\n"


### PR DESCRIPTION
This saves users from having to subclass the Slurm site.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
