### PR TITLE
DM-39885: Fully substitute symbolic environment variables in symbolic filenames

### DIFF
--- a/doc/changes/DM-39885.bugfix.rst
+++ b/doc/changes/DM-39885.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve nested symbolic names correctly 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
