### PR TITLE
DM-42421: Remove --slurmd-debug argument from Princeton site

### DIFF
--- a/python/lsst/ctrl/bps/parsl/sites/princeton.py
+++ b/python/lsst/ctrl/bps/parsl/sites/princeton.py
@@ -104,7 +104,7 @@ class Tiger(Slurm):
                     max_blocks=max_blocks,
                     parallelism=1.0,
                     worker_init=export_environment(),
-                    launcher=SrunLauncher(overrides="-K0 -k --slurmd-debug=verbose"),
+                    launcher=SrunLauncher(overrides="-K0 -k"),
                     cmd_timeout=cmd_timeout,
                 ),
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 parsl >= 1.2
 git+https://github.com/lsst/ctrl_bps@main#egg=lsst-ctrl-bps
+git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler
+git+https://github.com/lsst/pipe_base@main#egg=lsst-pipe-base
+git+https://github.com/lsst/ctrl_mpexec@main#egg=lsst-ctrl-mpexec
+documenteer==0.8.2


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
