### PR TITLE
DM-47399: max_workers is deprecated for max_workers_per_node

### DIFF
--- a/doc/changes/DM-47399.bugfix.md
+++ b/doc/changes/DM-47399.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an error caused by the deprecated `max_workers` parameter, which was removed in Parsl version 2024.09.09 following its deprecation in version 2024.03.04.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["lsst"]
 dependencies = [
     "lsst-ctrl-bps",
-    "parsl",
+    "parsl >= 2024.03.04",
 ]
 dynamic = ["version"]
 

--- a/python/lsst/ctrl/bps/parsl/sites/ccin2p3.py
+++ b/python/lsst/ctrl/bps/parsl/sites/ccin2p3.py
@@ -228,7 +228,7 @@ class Ccin2p3(SiteConfig):
                 # for each worker.
                 mem_per_worker=None,
                 # Caps the number of workers launched per node.
-                max_workers=1,
+                max_workers_per_node=1,
                 # Timeout period (in milliseconds) to be used by the
                 # executor components.
                 poll_period=1_000,

--- a/python/lsst/ctrl/bps/parsl/sites/local.py
+++ b/python/lsst/ctrl/bps/parsl/sites/local.py
@@ -53,7 +53,7 @@ class Local(SiteConfig):
         Each executor should have a unique ``label``.
         """
         cores = get_bps_config_value(self.site, "cores", int, required=True)
-        return [HighThroughputExecutor("local", provider=LocalProvider(), max_workers=cores)]
+        return [HighThroughputExecutor("local", provider=LocalProvider(), max_workers_per_node=cores)]
 
     def select_executor(self, job: "ParslJob") -> str:
         """Get the ``label`` of the executor to use to execute a job.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-parsl >= 1.2
+parsl >= 2024.03.04
 lsst-ctrl-bps @ git+https://github.com/lsst/ctrl_bps@main


### PR DESCRIPTION
Fixed an error caused by the deprecated `max_workers` parameter, which was removed in Parsl version 2024.09.09 following its deprecation in version 2024.03.04.

## Checklist

- [x] ran Jenkins [Details](https://rubin-ci.slac.stanford.edu/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/3072)
- [x] added a release note for user-visible changes to `doc/changes`
