### PR TITLE
DM-47673: v28 release notes (cherry-picked)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,11 +52,17 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -r a -v -n 3 --cov=python --cov=tests --cov-report=xml --cov-report=term --cov-branch
+          pytest -r a -v -n 3 --cov=python --cov=tests --cov-report=xml --cov-report=term --cov-branch \
+            --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   pypi:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         args:
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -24,10 +24,10 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.8
+    rev: v0.7.4
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc
-    rev: "v1.7.0"
+    rev: "v1.8.0"
     hooks:
       - id: numpydoc-validation

--- a/doc/changes/DM-44110.misc.rst
+++ b/doc/changes/DM-44110.misc.rst
@@ -1,1 +1,0 @@
-Updated selected unit tests to reflect the changes made in ``BpsConfig.__init__()``.

--- a/doc/changes/DM-45863.bugfix.md
+++ b/doc/changes/DM-45863.bugfix.md
@@ -1,3 +1,0 @@
-Resolved issue relating to the high throughput executor performing validation via checking of a resource spec dictionary.
-Until now, ctrl_bps_parsl was passing None instead of an empty dict when there are no resource requests associated with a task.
-

--- a/doc/changes/DM-47399.bugfix.md
+++ b/doc/changes/DM-47399.bugfix.md
@@ -1,1 +1,0 @@
-Fixed an error caused by the deprecated `max_workers` parameter, which was removed in Parsl version 2024.09.09 following its deprecation in version 2024.03.04.

--- a/doc/lsst.ctrl.bps.parsl/CHANGES.rst
+++ b/doc/lsst.ctrl.bps.parsl/CHANGES.rst
@@ -1,3 +1,19 @@
+lsst-ctrl-bps-parsl v28.0.0 2024-11-21
+======================================
+
+Bug Fixes
+---------
+
+- Resolved issue relating to the high throughput executor performing validation via checking of a resource spec dictionary.
+  Until now, ``ctrl_bps_parsl`` was passing `None`` instead of an empty `dict`` when there were no resource requests associated with a task. (`DM-45863 <https://rubinobs.atlassian.net/browse/DM-45863>`_)
+- Fixed an error caused by the deprecated ``max_workers`` parameter, which was removed in Parsl version 2024.09.09 following its deprecation in version 2024.03.04. (`DM-47399 <https://rubinobs.atlassian.net/browse/DM-47399>`_)
+
+Other Changes and Additions
+---------------------------
+
+- Updated selected unit tests to reflect the changes made in ``BpsConfig.__init__()``. (`DM-44110 <https://rubinobs.atlassian.net/browse/DM-44110>`_)
+
+
 lsst-ctrl-bps-parsl v27.0.0 2024-06-05
 ======================================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
