### PR TITLE
DM-49674 (v29): v29 release notes

### DIFF
--- a/doc/changes/dm-48539.feature.rst
+++ b/doc/changes/dm-48539.feature.rst
@@ -1,3 +1,0 @@
-* Added support for PBS/Torque.
-* Updated Princeton site to support new Tiger3 cluster.
-* Updated github actions.

--- a/doc/lsst.ctrl.bps.parsl/CHANGES.rst
+++ b/doc/lsst.ctrl.bps.parsl/CHANGES.rst
@@ -1,3 +1,12 @@
+lsst-ctrl-bps-parsl v29.0.0 2025-03-25
+======================================
+
+New Features
+------------
+
+- Added support for PBS/Torque and updated Princeton site to support new Tiger3 cluster. (`dm-48539 <https://rubinobs.atlassian.net/browse/dm-48539>`_)
+
+
 lsst-ctrl-bps-parsl v28.0.0 2024-11-21
 ======================================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 parsl >= 2024.03.04
-lsst-ctrl-bps @ git+https://github.com/lsst/ctrl_bps@main
+lsst-ctrl-bps @ git+https://github.com/lsst/ctrl_bps@v29.0.x


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
